### PR TITLE
Add files via upload

### DIFF
--- a/pl0.c
+++ b/pl0.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <malloc.h>
 
 #include "pl0.h"
 #include "set.c"
@@ -56,8 +57,47 @@ void getsym(void)
 	int i, k;
 	char a[MAXIDLEN + 1];
 
-	while (ch == ' '||ch == '\t')
-		getch();
+    // added & modified by nanahka 17-09-21 as labwork_1
+    // an un-recursive method to eliminate repeated comments
+    ////////////////////////////////////////////////
+    // two kinds of comments supported
+    // 1. line comment:     //...
+    // 2. block comment:    /*...*/
+    ////////////////////////////////////////////////
+	do
+    {
+        while (ch == ' '||ch == '\t')
+            getch();
+
+        if (ch == '/')
+        {
+            getch();
+            if (ch == '/')
+            {
+                cc = ll = 0;
+                ch = ' ';
+            }
+            else if (ch == '*')
+            {
+                do
+                {
+                    ch = ' ';
+                    while (ch != '*')
+                        getch();
+                    getch();
+                }
+                while (ch != '/');
+                ch = ' ';
+            }
+            else
+            {
+                sym = SYM_SLASH;
+                return;
+            }
+        }
+    }
+    while (ch == ' ');
+
 
 	if (isalpha(ch))
 	{ // symbol is a reserved word or an identifier.
@@ -103,7 +143,7 @@ void getsym(void)
 		}
 		else
 		{
-			sym = SYM_NULL;       // illegal?
+			error(37); // '=' expected.				// modified by nanhka 17-11-13
 		}
 	}
 	else if (ch == '>')
@@ -137,6 +177,16 @@ void getsym(void)
 			sym = SYM_LES;     // <
 		}
 	}
+	else if (ch == '[')		   // [			// added by nanahka 17-11-12
+	{
+		sym = SYM_LSQUARE;
+		getch();
+	}
+	else if (ch == ']')		   // ]			// added by nanahka 17-11-12
+	{
+		sym = SYM_RSQUARE;
+		getch();
+	}
 	else
 	{ // other tokens
 		i = NSYM;
@@ -155,6 +205,20 @@ void getsym(void)
 	}
 } // getsym
 
+//////////////////////////////////////////////////////////////////////
+//
+//			f			l			a
+//			INT			--			numerical constant			// allocate storage in stack
+//			LIT			--			numerical constant			// set a constant on top of the stack
+//			LOD			levelDiff	data address
+//			LODI		levelDiff	--(addr at top of the stack)
+//			STO			levelDiff	target address
+//			STOI		levelDiff	--(addr at top - 1 of the stack, data at top)
+//			CAL			levelDiff	procedure address
+//			JMP			--			procedure address
+//			JPC			--			procedure address			// if stack[top]==0, jump to an address
+//			OPR			--			type of algebraic/logical instructions
+//
 //////////////////////////////////////////////////////////////////////
 // generates (assembles) an instruction.
 void gen(int x, int y, int z)
@@ -186,11 +250,33 @@ void test(symset s1, symset s2, int n)
 } // test
 
 //////////////////////////////////////////////////////////////////////
-int dx;  // data allocation index
+int dx;  // data allocation index		// accumulated offset in current AR
 
+//////////////////////////////////////////////////////////////////////
+//TABLE: (table[0] for error declaration, correct entries start from table[1])
+//				name		kind			level		address						ptr
+// const		id			enter(kind)		--------value(stored in TABLE)---------	--
+// var			id			enter(kind)		level		dx							--
+// procedure	id			enter(kind)		level		cx(set by block(), line752)	ptr[0] is the number of its parameters
+// array		id			enter(kind)		level		dx ~ dx + ptr[0] - 1		ptr[1..ptr[0]] are volumes
+//																					 of the dimensions
+//*: Since all the entries created within a procedure will be released after the
+//  declaration of the procedure, except for the name of the procedure itself, all
+//  the entries in the table at a special moment are available for the statement
+//  to be analyzed.
+//////////////////////////////////////////////////////////////////////
 // enter object(constant, variable or procedre) into table.
 void enter(int kind)
 {
+	int position(char* id, int tx_beg);
+
+	if (kind == ID_PROCEDURE && position(id, TABLE_BEGIN) ||									// added by nanahka 17-11-20
+		kind != ID_PROCEDURE && position(id, tx_b))
+	{
+		error(31); // Redeclaration of an identifier.
+		return;
+	}
+
 	mask* mk;
 
 	tx++;
@@ -211,22 +297,46 @@ void enter(int kind)
 		mk->level = level;
 		mk->address = dx++;
 		break;
-	case ID_PROCEDURE:
+	case ID_PROCEDURE:					// modified by nanahka 17-11-20
 		mk = (mask*) &table[tx];
 		mk->level = level;
+		mk->ptr = (int*)malloc(sizeof(int));
+		*mk->ptr = 0;
+		break;
+	case ID_ARRAY:						// added by nanahka 17-11-13
+		mk = (mask*) &table[tx];
+		mk->level = level;
+		mk->address = dx;
+		int i = ptr[0], s = ptr[1];
+		while (--i) {s *= ptr[ptr[0]- i + 1];}
+		dx += s;
+		mk->ptr = ptr;
+		ptr = 0;
 		break;
 	} // switch
 } // enter
 
 //////////////////////////////////////////////////////////////////////
 // locates identifier in symbol table.
-int position(char* id)
+// language feature: Check if there is already a same var/const name within
+//   current block, or a procedure name in the whole TABLE. If NOT, return 0.
+//   This feature is to prevent wrong input of ids within compiling process,
+//   and support recursive calling of ancestor procedures.
+int position(char* id, int tx_beg)																// modified by nanahka 17-11-20
 {
 	int i;
-	strcpy(table[0].name, id);
 	i = tx + 1;
+	if (tx_beg)
+	{
+		strcpy(table[0].name, table[tx_beg].name);
+	}
+	strcpy(table[tx_beg].name, id);
 	while (strcmp(table[--i].name, id) != 0);
-	return i;
+	if (tx_beg)
+	{
+		strcpy(table[tx_beg].name, table[0].name);
+	}
+	return tx_beg == i ? i - tx_beg : i;
 } // position
 
 //////////////////////////////////////////////////////////////////////
@@ -259,12 +369,63 @@ void constdeclaration()
 } // constdeclaration
 
 //////////////////////////////////////////////////////////////////////
-void vardeclaration(void)
+int expression(symset fsys, symset ksys, int CONST_CHECK);
+void vardeclaration(symset fsys, symset ksys)
 {
-	if (sym == SYM_IDENTIFIER)
+	int con_expr;
+	symset set1, set;
+
+	if (sym == SYM_IDENTIFIER)			// added & modified by nanahka 17-11-14
 	{
-		enter(ID_VARIABLE);
 		getsym();
+		if (sym == SYM_LSQUARE)
+		{ // array declaration
+			char id_t[MAXIDLEN + 1];
+			strcpy(id_t, id);
+			int dim[MAXARYDIM + 1] = {};
+			do
+			{
+				getsym();
+				set = createset(SYM_RSQUARE, SYM_NULL);
+				set1 = uniteset(ksys, set);
+				con_expr = expression(set, set1, CONST_EXPR);
+				destroyset(set);
+				destroyset(set1);
+				if (con_expr <= 0 || con_expr > MAXARYVOL)
+				{
+					error(36); // Volume of a dimension is out of range.
+					break;
+				}
+				if ( (++dim[0]) > MAXARYDIM)
+				{
+					error(35); // There are too many dimensions.
+					--dim[0];
+					break;
+				}
+				dim[dim[0]] = con_expr;
+				if (sym != SYM_RSQUARE)
+				{
+					error(34); // ']' expected.				// if ']' lost, go finding the next '['
+				}
+				else
+				{
+					getsym();
+				}
+			}
+			while (sym == SYM_LSQUARE);
+			if (dim[0])										// modified by nanahka 17-11-13
+			{
+				ptr = (int*)malloc( (dim[0] + 1) * sizeof(int));
+				ptr[0] = dim[0]++;
+				while (--dim[0]) {ptr[dim[0]] = dim[dim[0]];}
+				strcpy(id, id_t);
+				enter(ID_ARRAY);
+			}
+		}
+		else
+		{ // variable declaration
+			enter(ID_VARIABLE);
+		}
 	}
 	else
 	{
@@ -276,7 +437,7 @@ void vardeclaration(void)
 void listcode(int from, int to)
 {
 	int i;
-	
+
 	printf("\n");
 	for (i = from; i < to; i++)
 	{
@@ -286,40 +447,143 @@ void listcode(int from, int to)
 } // listcode
 
 //////////////////////////////////////////////////////////////////////
-void factor(symset fsys)
+int factor(symset fsys, symset ksys, int CONST_CHECK)
 {
-	void expression(symset fsys);
-	int i;
-	symset set;
-	
-	test(facbegsys, fsys, 24); // The symbol can not be as the beginning of an expression.
+	int i, rv = 0;
+	symset set, set1;
 
-	while (inset(sym, facbegsys))
+	test(fac_first_sys, ksys, 24); // The symbol can not be as the beginning of an expression.
+											 // "factor" is unfamiliar for the user, thus "expression" used.
+	if (inset(sym, fac_first_sys))																// modified by nanahka 17-11-14
 	{
 		if (sym == SYM_IDENTIFIER)
 		{
-			if ((i = position(id)) == 0)
+			if ((i = position(id, TABLE_BEGIN)) == 0)
 			{
 				error(11); // Undeclared identifier.
+				getsym();
 			}
 			else
 			{
-				switch (table[i].kind)
+				switch (table[i].kind)															// modified by nanahka 17-11-14
 				{
 					mask* mk;
 				case ID_CONSTANT:
-					gen(LIT, 0, table[i].value);
+					if (CONST_CHECK)
+					{ // UNCONST_EXPR
+						gen(LIT, 0, table[i].value);
+					}
+					else
+					{ // CONST_EXPR
+						rv = table[i].value;
+					}
 					break;
 				case ID_VARIABLE:
-					mk = (mask*) &table[i];
-					gen(LOD, level - mk->level, mk->address);
+					if (CONST_CHECK)
+					{ // UNCONST_EXPR
+						mk = (mask*) &table[i];
+						gen(LOD, level - mk->level, mk->address);
+					}
+					else
+					{ // CONST_EXPR
+						error(28); // Variables can not be in a const expression.
+					}
 					break;
 				case ID_PROCEDURE:
 					error(21); // Procedure identifier can not be in an expression.
 					break;
+				case ID_ARRAY:																	// added by nanahka 17-11-15
+					if (CONST_CHECK)
+					{ // UNCONST_EXPR
+						mk = (mask*) &table[i];
+						getsym();
+						if (sym != SYM_LSQUARE)
+						{
+							error(38); // '[' expected
+							mk = 0;
+						}
+						else
+						{
+							getsym();
+						}
+						if (mk)
+						{
+							ptr = mk->ptr;
+							int d = *ptr; // d <- dimensions of the array
+							set = createset(SYM_RSQUARE, SYM_NULL);
+							set1 = uniteset(ksys, set);
+							expression(set, set1, UNCONST_EXPR);
+							if (sym != SYM_RSQUARE)
+							{
+								error(34); // ']' expected.
+							}
+							else
+							{
+								getsym();
+							}
+							--d;
+							while (sym == SYM_LSQUARE && d)
+							{
+								getsym(); // take '['
+								gen(LIT, 0, ptr[ptr[0] - d + 1]);
+								gen(OPR, 0, OPR_MUL);
+								expression(set, set1, UNCONST_EXPR);
+								gen(OPR, 0, OPR_ADD);
+								if (sym != SYM_RSQUARE)
+								{
+									error(34); // ']' expected.
+								}
+								else
+								{
+									getsym();
+								}
+								--d;
+							}
+							destroyset(set);
+							destroyset(set1);
+							if (!d)
+							{ // number of subscripts read == array dimensions
+								//gen(LIT, 0, sizeof(int));
+								//gen(OPR, 0, OPR_MUL);
+								gen(LIT, 0, mk->address);
+								gen(OPR, 0, OPR_ADD);
+							}
+							else
+							{ // number of subscripts read < array dimensions
+								error(29); // Too few subscripts.
+								i = 0;
+							}
+						} // if
+						if (!mk)
+						{ // discard the leftover parts of the subscripts
+							test(ksys, ksys, 19); // Incorrect symbol.
+						}
+						else																	// added by nanahka 17-11-15
+						{
+							if (sym == SYM_LSQUARE)
+							{
+								test(ksys, ksys, 30); // Too many subscripts.
+							}
+							gen(LODI, level - mk->level, 0);
+						}
+					}
+					else
+					{ // CONST_EXPR
+						error(28); // Variables can not be in a const expression.
+					}
+					break;
 				} // switch
-			}
-			getsym();
+				if (table[i].kind != ID_ARRAY)
+				{
+					getsym();
+					if (sym == SYM_LSQUARE)
+					{
+						error(27); // Applying the subscripts operator on non-array.
+						getsym();
+					}
+					test(ksys, ksys, 23); // The symbol can not be followed by a factor.
+				}
+			} // if
 		}
 		else if (sym == SYM_NUMBER)
 		{
@@ -328,15 +592,24 @@ void factor(symset fsys)
 				error(25); // The number is too great.
 				num = 0;
 			}
-			gen(LIT, 0, num);
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(LIT, 0, num);
+			}
+			else
+			{ // CONST_EXPR
+				rv = num;
+			}
 			getsym();
 		}
 		else if (sym == SYM_LPAREN)
 		{
 			getsym();
-			set = uniteset(createset(SYM_RPAREN, SYM_NULL), fsys);
-			expression(set);
+			set = createset(SYM_RPAREN, SYM_NULL);
+			set1 = uniteset(ksys, set);
+			rv = expression(set, set1, CONST_CHECK);											// modified by nanahka 17-11-14
 			destroyset(set);
+			destroyset(set1);
 			if (sym == SYM_RPAREN)
 			{
 				getsym();
@@ -347,69 +620,111 @@ void factor(symset fsys)
 			}
 		}
 		else if(sym == SYM_MINUS) // UMINUS,  Expr -> '-' Expr
-		{  
-			 getsym();
-			 expression(fsys);
-			 gen(OPR, 0, OPR_NEG);
+		{
+			getsym();
+			rv = factor(fsys, ksys, CONST_CHECK);												// modified by nanahka 17-11-14
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(OPR, 0, OPR_NEG);
+			}
+			else
+			{ // CONST_EXPR
+				rv = -rv;
+			}
 		}
-		test(fsys, createset(SYM_LPAREN, SYM_NULL), 23);
-	} // while
+		test(ksys, ksys, 23); // The symbol can not be followed by a factor.
+	} // if
+	return rv;																					// added by nanahka 17-11-14
 } // factor
 
 //////////////////////////////////////////////////////////////////////
-void term(symset fsys)
+int term(symset fsys, symset ksys, int CONST_CHECK)
 {
-	int mulop;
-	symset set;
-	
-	set = uniteset(fsys, createset(SYM_TIMES, SYM_SLASH, SYM_NULL));
-	factor(set);
+	int mulop, r, rv = 0;
+	symset set, set1;
+
+	set = expandset(fsys, SYM_TIMES, SYM_SLASH, SYM_NULL);
+	set1 = expandset(ksys, SYM_TIMES, SYM_SLASH, SYM_NULL);
+
+	rv = factor(set, set1, CONST_CHECK);														// modified by nanahka 17-11-14
 	while (sym == SYM_TIMES || sym == SYM_SLASH)
 	{
 		mulop = sym;
 		getsym();
-		factor(set);
+		r = factor(set, set1, CONST_CHECK);														// modified by nanahka 17-11-14
 		if (mulop == SYM_TIMES)
 		{
-			gen(OPR, 0, OPR_MUL);
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(OPR, 0, OPR_MUL);
+			}
+			else
+			{ // CONST_EXPR
+				rv *= r;
+			}
 		}
 		else
 		{
-			gen(OPR, 0, OPR_DIV);
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(OPR, 0, OPR_DIV);
+			}
+			else
+			{ // CONST_EXPR
+				rv /= r;
+			}
 		}
 	} // while
 	destroyset(set);
+	destroyset(set1);
+	return rv;
 } // term
 
 //////////////////////////////////////////////////////////////////////
-void expression(symset fsys)
+int expression(symset fsys, symset ksys, int CONST_CHECK)
 {
-	int addop;
-	symset set;
+	int addop, r, rv = 0;
+	symset set, set1;
 
-	set = uniteset(fsys, createset(SYM_PLUS, SYM_MINUS, SYM_NULL));
-	
-	term(set);
+	set = expandset(fsys, SYM_PLUS, SYM_MINUS, SYM_NULL);
+	set1 = expandset(ksys, SYM_PLUS, SYM_MINUS, SYM_NULL);
+
+	rv = term(set, set1, CONST_CHECK);															// modified by nanahka 17-11-14
 	while (sym == SYM_PLUS || sym == SYM_MINUS)
 	{
 		addop = sym;
 		getsym();
-		term(set);
+		r = term(set, set1, CONST_CHECK);														// modified by nanahka 17-11-14
 		if (addop == SYM_PLUS)
 		{
-			gen(OPR, 0, OPR_ADD);
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(OPR, 0, OPR_ADD);
+			}
+			else
+			{ // CONST_EXPR
+				rv += r;
+			}
 		}
 		else
 		{
-			gen(OPR, 0, OPR_MIN);
+			if (CONST_CHECK)
+			{ // UNCONST_EXPR
+				gen(OPR, 0, OPR_MIN);
+			}
+			else
+			{ // CONST_EXPR
+				rv -= r;
+			}
 		}
 	} // while
-
 	destroyset(set);
+	destroyset(set1);
+	return rv;
 } // expression
 
 //////////////////////////////////////////////////////////////////////
-void condition(symset fsys)
+void condition(symset fsys, symset ksys)
 {
 	int relop;
 	symset set;
@@ -417,13 +732,13 @@ void condition(symset fsys)
 	if (sym == SYM_ODD)
 	{
 		getsym();
-		expression(fsys);
+		expression(fsys, ksys, UNCONST_EXPR);													// modified by nanahka 17-11-13
 		gen(OPR, 0, 6);
 	}
 	else
 	{
-		set = uniteset(relset, fsys);
-		expression(set);
+		set = uniteset(relset, ksys);
+		expression(relset, set, UNCONST_EXPR);													// modified by nanahka 17-11-13
 		destroyset(set);
 		if (! inset(sym, relset))
 		{
@@ -433,7 +748,7 @@ void condition(symset fsys)
 		{
 			relop = sym;
 			getsym();
-			expression(fsys);
+			expression(fsys, ksys, UNCONST_EXPR);												// modified by nanahka 17-11-13
 			switch (relop)
 			{
 			case SYM_EQU:
@@ -460,71 +775,206 @@ void condition(symset fsys)
 } // condition
 
 //////////////////////////////////////////////////////////////////////
-void statement(symset fsys)
+void statement(symset fsys, symset ksys)
 {
 	int i, cx1, cx2;
 	symset set1, set;
 
 	if (sym == SYM_IDENTIFIER)
-	{ // variable assignment
+	{
 		mask* mk;
-		if (! (i = position(id)))
+		if (! (i = position(id, TABLE_BEGIN)))
 		{
 			error(11); // Undeclared identifier.
-		}
-		else if (table[i].kind != ID_VARIABLE)
-		{
-			error(12); // Illegal assignment.
-			i = 0;
-		}
-		getsym();
-		if (sym == SYM_BECOMES)
-		{
 			getsym();
 		}
-		else
-		{
-			error(13); // ':=' expected.
-		}
-		expression(fsys);
-		mk = (mask*) &table[i];
-		if (i)
-		{
-			gen(STO, level - mk->level, mk->address);
-		}
-	}
-	else if (sym == SYM_CALL)
-	{ // procedure call
-		getsym();
-		if (sym != SYM_IDENTIFIER)
-		{
-			error(14); // There must be an identifier to follow the 'call'.
-		}
-		else
-		{
-			if (! (i = position(id)))
+		else if (table[i].kind == ID_PROCEDURE)
+		{ // procedure call
+			getsym();
+			mk = (mask*) &table[i];
+			int n = *mk->ptr;
+			if (sym == SYM_LPAREN)
 			{
-				error(11); // Undeclared identifier.
-			}
-			else if (table[i].kind == ID_PROCEDURE)
+				getsym();
+				set = createset(SYM_COMMA, SYM_RPAREN, SYM_NULL);
+				set1 = uniteset_mul(ksys, set, exp_first_sys, 0);
+				if (n)
+				{
+					if (sym == SYM_RPAREN)
+					{
+						error(42); // Too few parameters in a procedure.
+					}
+					else
+					{
+						test(exp_first_sys, set1, 24); // The symbol can not be as the beginning of an expression.
+					}
+				}
+				while (inset(sym, exp_first_sys) && n--)
+				{
+					expression(set, set1, UNCONST_EXPR);
+					if (sym == SYM_COMMA)
+					{
+						getsym();
+					}
+					else if (sym == SYM_RPAREN)
+					{
+						getsym();
+						if (n)
+						{
+							error(42); // Too few parameters in a procedure.
+						}
+						break;
+					}
+					else
+					{
+						error(40); // Missing ',' or ')'.
+					}
+				} // while
+				destroyset(set);
+				destroyset(set1);
+				if (inset(sym, exp_first_sys))
+				{
+					error(39); // Too many parameters in a procedure.
+				}
+				if (sym == SYM_RPAREN)
+				{
+					getsym();
+				}
+			} // if
+			if (!n)
 			{
-				mask* mk;
-				mk = (mask*) &table[i];
 				gen(CAL, level - mk->level, mk->address);
+			}
+		}
+		else
+		{ // variable/array assignment
+			if (table[i].kind == ID_ARRAY)
+			{
+				getsym();
+				if (sym != SYM_LSQUARE)
+				{
+					error(38); // '[' expected
+					i = 0;
+				}
+				else
+				{
+					getsym();
+				}
+				if (i)
+				{
+					mk = (mask*) &table[i];
+					ptr = mk->ptr;
+					int d = *ptr; // d <- dimensions of the array
+					set = createset(SYM_RSQUARE, SYM_NULL);
+					set1 = uniteset(ksys, set);
+					expression(set, set1, UNCONST_EXPR);
+					if (sym != SYM_RSQUARE)
+					{
+						error(34); // ']' expected.
+					}
+					else
+					{
+						getsym();
+					}
+					--d;
+					while (sym == SYM_LSQUARE && d)
+					{
+						getsym(); // take '['
+						gen(LIT, 0, ptr[ptr[0] - d + 1]);
+						gen(OPR, 0, OPR_MUL);
+						expression(set, set1, UNCONST_EXPR);
+						gen(OPR, 0, OPR_ADD);
+						if (sym != SYM_RSQUARE)
+						{
+							error(34); // ']' expected.
+						}
+						else
+						{
+							getsym();
+						}
+						--d;
+					}
+					destroyset(set);
+					destroyset(set1);
+					if (!d)
+					{ // number of subscripts read == array dimensions
+						//gen(LIT, 0, sizeof(int));
+						//gen(OPR, 0, OPR_MUL);
+						gen(LIT, 0, mk->address);
+						gen(OPR, 0, OPR_ADD);
+					}
+					else
+					{ // number of subscripts read < array dimensions
+						error(29); // Too few subscripts.
+						i = 0;
+					}
+				} // if
+				set = createset(SYM_BECOMES, SYM_NULL);
+				set1 = uniteset(ksys, set);
+				if (!i)
+				{ // discard the leftover parts of the subscripts
+					test(set, set1, 19); // Incorrect symbol.
+				}
+				else if (sym == SYM_LSQUARE)														// added by nanahka 17-11-15
+				{
+					test(set, set1, 30); // Too many subscripts.
+				}
+				destroyset(set);
+				destroyset(set1);
+			}
+			else if (table[i].kind != ID_VARIABLE)													// modified by nanahka 17-11-14
+			{
+				error(12); // Illegal assignment.
+				i = 0;
+				getsym();
+			}
+			else
+			{ // ID_VARIABLE
+				getsym();
+			}
+			if (sym == SYM_LSQUARE)
+			{ // ID_VARIABLE / Illegal / Too many subscripts in array
+				error(27); // Applying the subscripts operator on non-array.
+				getsym();
+				set = createset(SYM_BECOMES, SYM_NULL);
+				set1 = uniteset(ksys, set);
+				test(set, set1, 19); // Incorrect symbol.
+				destroyset(set);
+				destroyset(set1);
+			}
+			if (sym == SYM_BECOMES)
+			{
+				getsym();
 			}
 			else
 			{
-				error(15); // A constant or variable can not be called. 
+				error(13); // ':=' expected.
 			}
-			getsym();
-		}
-	} 
+			expression(fsys, ksys, UNCONST_EXPR);													// modified by nanahka 17-11-13
+			mk = (mask*) &table[i];
+			if (i)
+			{
+				if (table[i].kind == ID_VARIABLE)
+				{
+					gen(STO, level - mk->level, mk->address);
+				}
+				else // ID_ARRAY
+				{
+					gen(STOI, level - mk->level, 0);
+				}
+			}
+		} // if
+	}
+/*	else if (sym == SYM_CALL)
+	{ // procedure call
+		;
+	}*/
 	else if (sym == SYM_IF)
 	{ // if statement
 		getsym();
-		set1 = createset(SYM_THEN, SYM_DO, SYM_NULL);
-		set = uniteset(set1, fsys);
-		condition(set);
+		set1 = createset(SYM_THEN, SYM_NULL);
+		set = uniteset_mul(ksys, set1, stat_first_sys, 0);
+		condition(set1, set);																	// modified by nanahka 17-11-13
 		destroyset(set1);
 		destroyset(set);
 		if (sym == SYM_THEN)
@@ -537,27 +987,28 @@ void statement(symset fsys)
 		}
 		cx1 = cx;
 		gen(JPC, 0, 0);
-		statement(fsys);
-		code[cx1].a = cx;	
+		statement(fsys, ksys);																	// modified by nanahka 17-11-13
+		code[cx1].a = cx;
 	}
 	else if (sym == SYM_BEGIN)
 	{ // block
 		getsym();
-		set1 = createset(SYM_SEMICOLON, SYM_END, SYM_NULL);
-		set = uniteset(set1, fsys);
-		statement(set);
-		while (sym == SYM_SEMICOLON || inset(sym, statbegsys))
+		set1 = createset(SYM_SEMICOLON, SYM_NULL);
+		set = uniteset_mul(ksys, set1, stat_first_sys, 0);										// modified by nanahka 17-11-13
+		setinsert(set, SYM_END);
+		do
 		{
-			if (sym == SYM_SEMICOLON)
+			statement(set1, set);
+			if (sym == SYM_SEMICOLON)															// modified by nanahka 17-11-13
 			{
 				getsym();
 			}
 			else
 			{
-				error(10);
+				error(10); // ';' expected.
 			}
-			statement(set);
-		} // while
+		}
+		while (inset(sym, stat_first_sys));
 		destroyset(set1);
 		destroyset(set);
 		if (sym == SYM_END)
@@ -566,7 +1017,7 @@ void statement(symset fsys)
 		}
 		else
 		{
-			error(17); // ';' or 'end' expected.
+			error(17); // 'end' expected.														// modified by nanahka 17-11-13
 		}
 	}
 	else if (sym == SYM_WHILE)
@@ -574,8 +1025,8 @@ void statement(symset fsys)
 		cx1 = cx;
 		getsym();
 		set1 = createset(SYM_DO, SYM_NULL);
-		set = uniteset(set1, fsys);
-		condition(set);
+		set = uniteset_mul(ksys, set1, stat_first_sys, 0);
+		condition(set1, set);																	// modified by nanahka 17-11-13
 		destroyset(set1);
 		destroyset(set);
 		cx2 = cx;
@@ -588,34 +1039,36 @@ void statement(symset fsys)
 		{
 			error(18); // 'do' expected.
 		}
-		statement(fsys);
+		statement(fsys, ksys);
 		gen(JMP, 0, cx1);
 		code[cx2].a = cx;
 	}
-	test(fsys, phi, 19);
+	test(ksys, ksys, 19);																		// modified by nanahka 17-11-20
 } // statement
-			
+
 //////////////////////////////////////////////////////////////////////
-void block(symset fsys)
+void block(symset fsys, symset ksys)	// fsys/ksys is the Follow/KeyWord set of current block
 {
 	int cx0; // initial code index
 	mask* mk;
 	int block_dx;
-	int savedTx;
+	int block_tx = tx_b;																// added by nanahka 17-11-20
+	int savedTx, savedDx;																// added by nanahka 17-11-20
 	symset set1, set;
 
 	dx = 3;
 	block_dx = dx;
-	mk = (mask*) &table[tx];
-	mk->address = cx;
-	gen(JMP, 0, 0);
+	mk = (mask*) &table[tx_b];	// when block() called after creating a procedure, this is the entry of the procedure
+	mk->address = cx;			// enter index of the next code JMP in "address" of the procedure
+	gen(JMP, 0, 0);				// generate an instruction to jump to the procedure, the address filled later
 	if (level > MAXLEVEL)
 	{
 		error(32); // There are too many levels.
 	}
 	do
 	{
-		if (sym == SYM_CONST)
+		tx_b = block_tx; // set tx_b to the beginning index of current block;					// added by nanahka 17-11-20
+		if (sym == SYM_CONST)		//WARNING: other types of declaration precede the procedure!!! or tx_b will be reset!
 		{ // constant declarations
 			getsym();
 			do
@@ -637,17 +1090,18 @@ void block(symset fsys)
 			}
 			while (sym == SYM_IDENTIFIER);
 		} // if
-
 		if (sym == SYM_VAR)
 		{ // variable declarations
 			getsym();
-			do
+			do																					// modified by nanahka 17-11-14
 			{
-				vardeclaration();
+				set = createset(SYM_COMMA, SYM_SEMICOLON, SYM_NULL);
+				set1 = uniteset_mul(ksys, set, blk_first_sys, 0);
+				vardeclaration(set, set1);
 				while (sym == SYM_COMMA)
 				{
 					getsym();
-					vardeclaration();
+					vardeclaration(set, set1);
 				}
 				if (sym == SYM_SEMICOLON)
 				{
@@ -657,12 +1111,15 @@ void block(symset fsys)
 				{
 					error(5); // Missing ',' or ';'.
 				}
+				destroyset(set);
+				destroyset(set1);
 			}
 			while (sym == SYM_IDENTIFIER);
 		} // if
 		block_dx = dx; //save dx before handling procedure call!
 		while (sym == SYM_PROCEDURE)
 		{ // procedure declarations
+			int PROC_CREATED = TRUE;
 			getsym();
 			if (sym == SYM_IDENTIFIER)
 			{
@@ -672,62 +1129,119 @@ void block(symset fsys)
 			else
 			{
 				error(4); // There must be an identifier to follow 'const', 'var', or 'procedure'.
+				PROC_CREATED = FALSE;
+			}
+			level++;																			// modified by nanahka 17-11-20
+			savedTx = tx_b = tx; // entry of the procedure created(if succeeded)
+			if (sym == SYM_LPAREN)
+			{
+				getsym();
+				savedDx = dx; // n parameters bound to dx -n-1,-n,...,-1. The actual dx doesn't increase.
+				int n = 0;
+				while (sym == SYM_IDENTIFIER)
+				{
+					char id_t[MAXIDLEN + 1];
+					strcpy(id_t, id);
+					getsym();
+					set = createset(SYM_COMMA, SYM_RPAREN, SYM_LSQUARE, SYM_NULL);
+					set1 = uniteset_mul(ksys, set, blk_first_sys, 0);
+					setinsert_mul(set1, SYM_IDENTIFIER, SYM_SEMICOLON, SYM_NULL);
+					test(set, set1, 40); // Missing ',' or ')'.
+					destroyset(set);
+					destroyset(set1);
+					if (sym == SYM_LSQUARE)
+					{
+						error(41); // Array type as parameter forbidden.
+						set = createset(SYM_COMMA, SYM_RPAREN, SYM_NULL);
+						set1 = uniteset_mul(ksys, set, blk_first_sys, 0);
+						setinsert_mul(set1, SYM_IDENTIFIER, SYM_SEMICOLON, SYM_NULL);
+						test(set, set1, 40); // Missing ',' or ')'.
+						destroyset(set);
+						destroyset(set1);
+					}
+					else
+					{
+						if ( (++n) > MAXFUNPMT)
+						{
+							error(39); // Too many parameters in a procedure.
+							--n;
+							break;
+						}
+						strcpy(id, id_t);
+						dx = 0;				// as a sign if backpatching fails
+						enter(ID_VARIABLE); // address will entered later
+					}
+					if (sym == SYM_COMMA)
+					{
+						getsym();
+					}
+					else if (sym == SYM_RPAREN)
+					{
+						break;
+					}
+				} // while
+				if (sym == SYM_RPAREN)
+				{
+					getsym();
+				}
+				dx = savedDx;
+				if (PROC_CREATED)
+				{
+					*table[tx_b].ptr = n;
+					while (n--)
+					{
+						mask *mk = (mask*)&table[tx - n];
+						mk->address = -n - 1;
+					}
+				}
+			}
+			else
+			{
+				*table[tx_b].ptr = 0;
 			}
 
-
+			set1 = createset(SYM_SEMICOLON, SYM_NULL);
+			set = uniteset_mul(ksys, set1, blk_first_sys, 0);
+			test(set1, set, 26); // Missing ';'.
 			if (sym == SYM_SEMICOLON)
 			{
 				getsym();
 			}
-			else
-			{
-				error(5); // Missing ',' or ';'.
-			}
-
-			level++;
-			savedTx = tx;
-			set1 = createset(SYM_SEMICOLON, SYM_NULL);
-			set = uniteset(set1, fsys);
-			block(set);
+			block(set1, set);																	// modified by nanahka 17-11-13
 			destroyset(set1);
 			destroyset(set);
-			tx = savedTx;
+			tx = savedTx;	// all the codes of the procedure generated, release the entries in TABLE
 			level--;
 
 			if (sym == SYM_SEMICOLON)
 			{
 				getsym();
-				set1 = createset(SYM_IDENTIFIER, SYM_PROCEDURE, SYM_NULL);
-				set = uniteset(statbegsys, set1);
-				test(set, fsys, 6);
-				destroyset(set1);
-				destroyset(set);
 			}
 			else
 			{
-				error(5); // Missing ',' or ';'.
+				error(26); // Missing ';'.														// modified by nanahka 17-11-13
 			}
 		} // while
 		dx = block_dx; //restore dx after handling procedure call!
-		set1 = createset(SYM_IDENTIFIER, SYM_NULL);
-		set = uniteset(statbegsys, set1);
-		test(set, declbegsys, 7);
-		destroyset(set1);
+		//set1 = createset(SYM_IDENTIFIER, SYM_NULL);
+		set = uniteset(blk_first_sys, ksys);
+		test(blk_first_sys, set, 7); // Declaration/Statement expected.							// modified by nanahka 17-11-13
+		//destroyset(set1);
 		destroyset(set);
 	}
-	while (inset(sym, declbegsys));
+	while (inset(sym, decl_first_sys));
 
-	code[mk->address].a = cx;
-	mk->address = cx;
+	code[mk->address].a = cx;	// fill the address of JMP to the procedure(no code belonging to it generated during declaration)
+	mk->address = cx;			// change the "address" attribute of the procedure to its true entrance, save 1 JMP
 	cx0 = cx;
-	gen(INT, 0, block_dx);
-	set1 = createset(SYM_SEMICOLON, SYM_END, SYM_NULL);
-	set = uniteset(set1, fsys);
-	statement(set);
-	destroyset(set1);
-	destroyset(set);
+	gen(INT, 0, block_dx);		// distribute storage for Static Link(<-bp), Dynamic Link, Return Address, and variables
+	//set1 = createset(SYM_SEMICOLON, SYM_END, SYM_NULL);
+	//set = uniteset(fsys, ksys);
+	statement(fsys, ksys);																		// modified by nanahka 17-11-13
+	//destroyset(set1);
+	//destroyset(set);
 	gen(OPR, 0, OPR_RET); // return
-	test(fsys, phi, 8); // test for error: Follow the statement is an incorrect symbol.
+	test(ksys, ksys, 8); // Follow the statement is an incorrect symbol.						// modified by nanahka 17-11-20
 	listcode(cx0, cx);
 } // block
 
@@ -735,7 +1249,7 @@ void block(symset fsys)
 int base(int stack[], int currentLevel, int levelDiff)
 {
 	int b = currentLevel;
-	
+
 	while (levelDiff--)
 		b = stack[b];
 	return b;
@@ -827,10 +1341,18 @@ void interpret()
 		case LOD:
 			stack[++top] = stack[base(stack, b, i.l) + i.a];
 			break;
+		case LODI:
+			stack[top] = stack[base(stack, b, i.l) + stack[top]];
+			break;
 		case STO:
 			stack[base(stack, b, i.l) + i.a] = stack[top];
 			printf("%d\n", stack[top]);
 			top--;
+			break;
+		case STOI:
+			stack[base(stack, b, i.l) + stack[top - 1]] = stack[top];
+			printf("%d\n", stack[top]);
+			top -= 2;
 			break;
 		case CAL:
 			stack[top + 1] = base(stack, b, i.l);
@@ -859,12 +1381,12 @@ void interpret()
 } // interpret
 
 //////////////////////////////////////////////////////////////////////
-void main ()
+int main ()
 {
 	FILE* hbin;
 	char s[80];
 	int i;
-	symset set, set1, set2;
+	//symset set, set1, set2;																	// modified by nanahka 17-11-14
 
 	printf("Please input source file name: "); // get file name to be compiled
 	scanf("%s", s);
@@ -874,13 +1396,18 @@ void main ()
 		exit(1);
 	}
 
-	phi = createset(SYM_NULL);
-	relset = createset(SYM_EQU, SYM_NEQ, SYM_LES, SYM_LEQ, SYM_GTR, SYM_GEQ, SYM_NULL);
-	
-	// create begin symbol sets
-	declbegsys = createset(SYM_CONST, SYM_VAR, SYM_PROCEDURE, SYM_NULL);
-	statbegsys = createset(SYM_BEGIN, SYM_CALL, SYM_IF, SYM_WHILE, SYM_NULL);
-	facbegsys = createset(SYM_IDENTIFIER, SYM_NUMBER, SYM_LPAREN, SYM_MINUS, SYM_NULL);
+	 // create First/Follow/KeyWord symbol sets													// modified by nanahka 17-11-13
+	phi 				= createset(SYM_NULL);
+	relset 				= createset(SYM_EQU, SYM_NEQ, SYM_LES, SYM_LEQ, SYM_GTR, SYM_GEQ, SYM_NULL);
+
+	decl_first_sys 		= createset(SYM_CONST, SYM_VAR, SYM_PROCEDURE, SYM_NULL);
+	stat_first_sys 		= createset(SYM_IDENTIFIER, SYM_BEGIN, /*SYM_CALL,*/ SYM_IF, SYM_WHILE, SYM_NULL);	// deleted by nanahka 17-11-20
+	blk_first_sys 		= uniteset(decl_first_sys, stat_first_sys);
+	fac_first_sys 		= createset(SYM_IDENTIFIER, SYM_NUMBER, SYM_LPAREN, SYM_MINUS, SYM_NULL);
+	exp_first_sys		= fac_first_sys;
+
+	main_blk_follow_sys = createset(SYM_PERIOD, SYM_NULL);
+
 
 	err = cc = cx = ll = 0; // initialize global variables
 	ch = ' ';
@@ -888,18 +1415,24 @@ void main ()
 
 	getsym();
 
-	set1 = createset(SYM_PERIOD, SYM_NULL);
-	set2 = uniteset(declbegsys, statbegsys);
-	set = uniteset(set1, set2);
-	block(set);
-	destroyset(set1);
-	destroyset(set2);
-	destroyset(set);
+//	set1 = createset(SYM_PERIOD, SYM_NULL);
+//	set2 = uniteset(declbegsys, statbegsys);
+//	set = uniteset(set1, set2);
+	block(main_blk_follow_sys, main_blk_follow_sys);
+//	destroyset(set1);
+//	destroyset(set2);
+//	destroyset(set);
 	destroyset(phi);
 	destroyset(relset);
-	destroyset(declbegsys);
-	destroyset(statbegsys);
-	destroyset(facbegsys);
+	destroyset(decl_first_sys);
+	destroyset(stat_first_sys);
+	destroyset(blk_first_sys);
+	destroyset(fac_first_sys);
+	//destroyset(exp_first_sys);
+	destroyset(main_blk_follow_sys);
+//	destroyset(declbegsys);
+//	destroyset(statbegsys);
+//	destroyset(facbegsys);
 
 	if (sym != SYM_PERIOD)
 		error(9); // '.' expected.
@@ -915,6 +1448,9 @@ void main ()
 	else
 		printf("There are %d error(s) in PL/0 program.\n", err);
 	listcode(0, cx);
+
+	getchar();
+	getchar();
 } // main
 
 //////////////////////////////////////////////////////////////////////

--- a/pl0.h
+++ b/pl0.h
@@ -1,18 +1,29 @@
 #include <stdio.h>
 
-#define NRW        11     // number of reserved words
+#define TRUE	   1
+#define FALSE	   0
+
+#define NRW        10     // number of reserved words
 #define TXMAX      500    // length of identifier table
 #define MAXNUMLEN  14     // maximum number of digits in numbers
-#define NSYM       10     // maximum number of symbols in array ssym and csym
+#define NSYM       11     // maximum number of symbols in array ssym and csym
 #define MAXIDLEN   10     // length of identifiers
+#define MAXARYDIM  10	  // maximum number of dimensions of an array							// added by nanahka 17-11-12
+#define MAXARYVOL  200	  // maximum volume of a dimension of an array							// added by nanahka 17-11-12
+#define MAXFUNPMT  10	  // maximum number of parameters of a procedure						// added by nanahka 17-11-20
 
-#define MAXADDRESS 32767  // maximum address
+#define MAXADDRESS 32767  // maximum numerical constant											// modified by nanahka 17-11-20
 #define MAXLEVEL   32     // maximum depth of nesting block
 #define CXMAX      500    // size of code array
 
-#define MAXSYM     30     // maximum number of symbols  
+#define MAXSYM     32     // maximum number of symbols
 
 #define STACKSIZE  1000   // maximum storage
+
+#define CONST_EXPR 0	  // the expression is constant											// added by nanahka 17-11-14
+#define UNCONST_EXPR 1	  // the expression is not constant
+
+#define TABLE_BEGIN 0	  // the beginning index of the TABLE, used in position()				// added by nanahka 17-11-14
 
 enum symtype
 {
@@ -32,6 +43,8 @@ enum symtype
 	SYM_GEQ,
 	SYM_LPAREN,
 	SYM_RPAREN,
+	SYM_LSQUARE,				// 2 square brackets added by nanahka 17-11-12
+	SYM_RSQUARE,
 	SYM_COMMA,
 	SYM_SEMICOLON,
 	SYM_PERIOD,
@@ -42,20 +55,21 @@ enum symtype
 	SYM_THEN,
 	SYM_WHILE,
 	SYM_DO,
-	SYM_CALL,
+	//SYM_CALL,					// deleted by nanahka 17-11-20
 	SYM_CONST,
 	SYM_VAR,
-	SYM_PROCEDURE
-};
+	SYM_PROCEDURE,
+	SYM_AMPERSAND				// added by nanahka 17-11-20
+};	// total number = MACRO MAXSYM, maintenance needed!!!
 
 enum idtype
 {
-	ID_CONSTANT, ID_VARIABLE, ID_PROCEDURE
+	ID_CONSTANT, ID_VARIABLE, ID_PROCEDURE, ID_ARRAY
 };
 
 enum opcode
 {
-	LIT, OPR, LOD, STO, CAL, INT, JMP, JPC
+	LIT, OPR, LOD, LODI, STO, STOI, CAL, INT, JMP, JPC											// added by nanahka 17-11-14
 };
 
 enum oprcode
@@ -83,8 +97,8 @@ char* err_msg[] =
 /*  3 */    "There must be an '=' to follow the identifier.",
 /*  4 */    "There must be an identifier to follow 'const', 'var', or 'procedure'.",
 /*  5 */    "Missing ',' or ';'.",
-/*  6 */    "Incorrect procedure name.",
-/*  7 */    "Statement expected.",
+/*  6 */    "Incorrect procedure name.",									// unused
+/*  7 */    "Declaration/Statement expected.",
 /*  8 */    "Follow the statement is an incorrect symbol.",
 /*  9 */    "'.' expected.",
 /* 10 */    "';' expected.",
@@ -92,9 +106,9 @@ char* err_msg[] =
 /* 12 */    "Illegal assignment.",
 /* 13 */    "':=' expected.",
 /* 14 */    "There must be an identifier to follow the 'call'.",
-/* 15 */    "A constant or variable can not be called.",
+/* 15 */    "",																				// change to calling operator error
 /* 16 */    "'then' expected.",
-/* 17 */    "';' or 'end' expected.",
+/* 17 */    "'end' expected.",					// modified by nanahka 17-11-13
 /* 18 */    "'do' expected.",
 /* 19 */    "Incorrect symbol.",
 /* 20 */    "Relative operators expected.",
@@ -103,13 +117,23 @@ char* err_msg[] =
 /* 23 */    "The symbol can not be followed by a factor.",
 /* 24 */    "The symbol can not be as the beginning of an expression.",
 /* 25 */    "The number is too great.",
-/* 26 */    "",
-/* 27 */    "",
-/* 28 */    "",
-/* 29 */    "",
-/* 30 */    "",
-/* 31 */    "",
-/* 32 */    "There are too many levels."
+/* 26 */    "Missing ';'.",						// 26 added by nanahka 17-11-13
+/* 27 */    "Applying the index operator on non-array.",		// 27-29 added by nanahka 17-11-14
+/* 28 */    "Variables can not be in a const expression.",
+/* 29 */    "Too few subscripts.",
+/* 30 */    "Too many subscripts.",				// 30 added by nanahka 17-11-15
+/* 31 */    "Redeclaration of an identifier.",	// 31 added by nanahka 17-11-20
+/* 32 */    "There are too many levels.",
+/* 33 */	"Numeric constant expected.",		// 33-36 added by nanahka 17-11-12
+/* 34 */	"']' expected.",
+/* 35 */	"There are too many dimensions.",
+/* 36 */	"Volume of a dimension is out of range.",
+/* 37 */	"'=' expected.",					// 37 added by nanahka 17-11-13
+/* 38 */	"'[' expected.",					// 38 added by nanahka 17-11-14
+/* 39 */	"Too many parameters in a procedure.",	// 39-42 added by nanahka 17-11-20
+/* 40 */	"Missing ',' or ')'.",
+/* 41 */	"Array type as parameter forbidden.",
+/* 42 */	"Too few parameters in a procedure."
 };
 
 //////////////////////////////////////////////////////////////////////
@@ -117,6 +141,7 @@ char ch;         // last character read
 int  sym;        // last symbol read
 char id[MAXIDLEN + 1]; // last identifier read
 int  num;        // last number read
+int  *ptr;		 // a link list containing dimensions of an array								// added by nanahka 17-11-12
 int  cc;         // character count
 int  ll;         // line length
 int  kk;
@@ -124,6 +149,7 @@ int  err;
 int  cx;         // index of current instruction to be generated.
 int  level = 0;
 int  tx = 0;
+int  tx_b = 0;	 // index of the beginning of current block in TABLE
 
 char line[80];
 
@@ -132,31 +158,32 @@ instruction code[CXMAX];
 char* word[NRW + 1] =
 {
 	"", /* place holder */
-	"begin", "call", "const", "do", "end","if",
+	"begin", /*"call",*/ "const", "do", "end","if",												// deleted by nanahka 17-11-20
 	"odd", "procedure", "then", "var", "while"
 };
 
 int wsym[NRW + 1] =
 {
-	SYM_NULL, SYM_BEGIN, SYM_CALL, SYM_CONST, SYM_DO, SYM_END,
+	SYM_NULL, SYM_BEGIN, /*SYM_CALL,*/ SYM_CONST, SYM_DO, SYM_END,								// deleted by nanahka 17-11-20
 	SYM_IF, SYM_ODD, SYM_PROCEDURE, SYM_THEN, SYM_VAR, SYM_WHILE
 };
 
 int ssym[NSYM + 1] =
 {
 	SYM_NULL, SYM_PLUS, SYM_MINUS, SYM_TIMES, SYM_SLASH,
-	SYM_LPAREN, SYM_RPAREN, SYM_EQU, SYM_COMMA, SYM_PERIOD, SYM_SEMICOLON
+	SYM_LPAREN, SYM_RPAREN, SYM_EQU, SYM_COMMA, SYM_PERIOD, SYM_SEMICOLON,
+	SYM_AMPERSAND																				// added 17-11-20
 };
 
 char csym[NSYM + 1] =
 {
-	' ', '+', '-', '*', '/', '(', ')', '=', ',', '.', ';'
+	' ', '+', '-', '*', '/', '(', ')', '=', ',', '.', ';', '&'									// added 17-11-20
 };
 
-#define MAXINS   8
+#define MAXINS   10																		// added & modified by nanahka 17-11-14
 char* mnemonic[MAXINS] =
 {
-	"LIT", "OPR", "LOD", "STO", "CAL", "INT", "JMP", "JPC"
+	"LIT", "OPR", "LOD", "LODI", "STO", "STOI", "CAL", "INT", "JMP", "JPC"
 };
 
 typedef struct
@@ -164,6 +191,7 @@ typedef struct
 	char name[MAXIDLEN + 1];
 	int  kind;
 	int  value;
+	int  *ptr;							// added by nanahka 17-11-12 for dimensions in an array
 } comtab;
 
 comtab table[TXMAX];
@@ -174,6 +202,7 @@ typedef struct
 	int   kind;
 	short level;
 	short address;
+	int   *ptr;							// added by nanahka 17-11-12
 } mask;
 
 FILE* infile;

--- a/set.c
+++ b/set.c
@@ -9,10 +9,10 @@ symset uniteset(symset s1, symset s2)
 {
 	symset s;
 	snode* p;
-	
+
 	s1 = s1->next;
 	s2 = s2->next;
-	
+
 	s = p = (snode*) malloc(sizeof(snode));
 	while (s1 && s2)
 	{
@@ -23,9 +23,15 @@ symset uniteset(symset s1, symset s2)
 			p->elem = s1->elem;
 			s1 = s1->next;
 		}
-		else
+		else if (s1->elem > s2->elem)															// modified by nanahka 17-11-20
 		{
 			p->elem = s2->elem;
+			s2 = s2->next;
+		}
+		else
+		{
+			p->elem = s1->elem;
+			s1 = s1->next;
 			s2 = s2->next;
 		}
 	}
@@ -36,7 +42,7 @@ symset uniteset(symset s1, symset s2)
 		p = p->next;
 		p->elem = s1->elem;
 		s1 = s1->next;
-		
+
 	}
 
 	while (s2)
@@ -52,6 +58,23 @@ symset uniteset(symset s1, symset s2)
 	return s;
 } // uniteset
 
+symset uniteset_mul(symset s1, .../* NULL */)
+{
+	va_list list;
+	symset s = s1;
+
+	va_start(list, s1);
+	s1 = va_arg(list, symset);
+
+	while (s1)
+	{
+		s = uniteset(s, s1);
+		s1 = va_arg(list, symset);
+	}
+	va_end(list);
+	return s;
+}
+
 void setinsert(symset s, int elem)
 {
 	snode* p = s;
@@ -61,12 +84,55 @@ void setinsert(symset s, int elem)
 	{
 		p = p->next;
 	}
-	
+
+	if (p->next && p->next->elem == elem)														// added by nanahka 17-11-20
+	{
+		return;
+	}
+
 	q = (snode*) malloc(sizeof(snode));
 	q->elem = elem;
 	q->next = p->next;
 	p->next = q;
 } // setinsert
+
+void setinsert_mul(symset s, .../* SYM_NULL */)
+{
+	va_list list;
+	int elem;
+
+	va_start(list, s);
+	elem = va_arg(list, int);
+
+	while (elem)
+	{
+		setinsert(s, elem);
+		elem = va_arg(list, int);
+	}
+	va_end(list);
+}
+
+symset expandset(symset s, .../* SYM_NULL */)
+{
+	va_list list;
+	symset p;
+	int elem;
+
+	p = (snode*) malloc(sizeof(snode));
+	p->next = NULL;
+
+	va_start(list, s);
+	elem = va_arg(list, int);
+
+	while (elem)
+	{
+		setinsert(p, elem);
+		elem = va_arg(list, int);
+	}
+	va_end(list);
+
+	return uniteset(s, p);
+} // expandset
 
 symset createset(int elem, .../* SYM_NULL */)
 {

--- a/set.h
+++ b/set.h
@@ -5,9 +5,13 @@ typedef struct snode
 {
 	int elem;
 	struct snode* next;
-} snode, *symset;
+} snode, *symset;			// elem of head node not used
 
-symset phi, declbegsys, statbegsys, facbegsys, relset;
+symset phi, 														// added by nanahka 17-11-13
+	   blk_first_sys, decl_first_sys, stat_first_sys,
+	   exp_first_sys, fac_first_sys,
+	   main_blk_follow_sys,
+	   relset;
 
 symset createset(int data, .../* SYM_NULL */);
 void destroyset(symset s);


### PR DESCRIPTION
函数传参完成了初步测试。
1. 增加了当前作用域内冲突声明的检测。在当前作用域内已声明过的非过程名字再次声明时会报错（31），在当前作用域及其先祖作用域内已声明过的过程名再次声明时会报错（31）。扩大过程名字的检测范围是为了更好地支持递归调用，禁止声明父过程的名字，防止声明错误在编译阶段无法检测。为此，修改了函数position的实现，增加参数tx_beg，记录当前查找的作用域的开始位置。该参数只有在检测冲突声明时才置非0，过去已存在的调用均为0。为了传递正确的tx_beg，又添加了全局变量tx_b，它在每次声明过程前修改，并且进入过程体后由block_dx记录它的值，因为一个过程体内可能声明多个子过程，每个过程都要更改tx_b的值。所以要提前记录当前域的tx_b值，以使与过程声明间杂的变量声明可以拿到正确的tx_b值。
2. 利用加入数组时增加的符号表项ptr，记录过程名字附属的参数的信息。由于现在参数只有整型，只需一个域记录个数即可。之后添加地址和过程参数时还需要记录各参数的类型。
3. 增加了声明带参函数的代码。参数在活动记录中正向储存（与C不同），并且在过程头声明时直接加入符号表，其地址直接绑定到调用函数存放实参的地方。因此，越早声明的参数相对偏移（为负）越小，其值要在扫描完全部参数后才能确定。
4. 在声明和调用含参过程的代码中提供了多种错误检测，包括超过参数个数上限，参数过多、过少，参数不能为数组、缺少分隔符等。
5. 删除了call符号，改为直接使用名字调用。
6. 对set.c中set集合的操作增加了查重功能，对于重复的符号在集合合并、扩大时只添加一个，减少查找特定符号的时间。
7. #debug 修正了在语句和程序块结束时，出现编译错误有可能会重复报错的bug。这个bug源于这两个函数末尾的错误检查test(fsys,ksys,*)，如果语句或块后的符号（比如；）漏写了（这是常有的事），在这里会通不过检测而报错，从而先于后面真正的错误而报错。这里test的参数选择照搬自原来的pl0程序，虽然整个错误检测系统已经重构了一遍，去除了一些bug，但是仍然有很多问题。在正确的位置检测出正确个数、内容正确的错误，并且尽可能保证后面的分析能继续下去，应当是本实验最难的地方。这里修改成test(ksys,ksys,*)，弱化了test函数的作用，也许会在某些错误下引发新的问题，还需要继续修改。
